### PR TITLE
changing main MMLToCHTML to SVG

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mml-to-svg",
   "version": "0.2.0",
   "description": "The MathJax wrapper to convert MML to SVG",
-  "main": "MMLToCHTML.js",
+  "main": "MMLToSVG.js",
   "keywords": [
     "SVG",
     "MML",


### PR DESCRIPTION
In Angular , throwing cannot resolve mml-to-svg module,need change main file